### PR TITLE
Fix: accordion header

### DIFF
--- a/sources/lib/components/station_ui/html/accordion.ex
+++ b/sources/lib/components/station_ui/html/accordion.ex
@@ -98,7 +98,7 @@ defmodule StationUI.HTML.Accordion do
             <.icon name="hero-folder-solid" aria-hidden="true" class="h-8 w-8 md:h-10 md:w-10" />
           </span>
 
-          <span class="text-xl lg:text-2xl"><%= render_slot(header) %></span>
+          <span><%= render_slot(header) %></span>
 
           <span
             aria-hidden="true"


### PR DESCRIPTION
## In this PR

Remove redundant classes in the `<span>` tag in the accordion header that was preventing the user from being able to override with their own header classes