### PR TITLE
Fix: Tooltip direction styling

### DIFF
--- a/sources/lib/components/station_ui/html/tooltip.ex
+++ b/sources/lib/components/station_ui/html/tooltip.ex
@@ -10,6 +10,7 @@ defmodule StationUI.HTML.Tooltip do
 
   attr :id, :string, required: true
   attr :direction, :string, default: "bottom", values: ["top", "bottom"]
+  attr :class, :string, default: "text-base font-medium leading-6"
 
   slot :inner_block
 
@@ -17,7 +18,7 @@ defmodule StationUI.HTML.Tooltip do
     ~H"""
     <div class={direction_classes(@direction)} id={@id} role="tooltip">
       <.icon name="hero-information-circle" class="h-6 w-6 text-blue-100" />
-      <span class="z-10 text-base font-medium leading-6 text-white">
+      <span class={["z-10 text-white" | List.wrap(@class)]}>
         {render_slot(@inner_block)}
       </span>
     </div>
@@ -25,10 +26,10 @@ defmodule StationUI.HTML.Tooltip do
   end
 
   defp direction_classes("top") do
-    "gap-x-1.5 p-2.5 pl-1.5 z-50 hidden peer-focus-within/target:inline-flex peer-hover/target:inline-flex absolute bottom-full mb-[calc(var(--tooltip-arrow-size)/1.5)] items-center min-w-max rounded-lg bg-slate-900 left-0 after:absolute after:content-[''] after:top-full after:left-1/2 after:-translate-x-1/2 after:bg-inherit after:rounded-sm after:h-[var(--tooltip-arrow-size)] after:w-[var(--tooltip-arrow-size)] after:-translate-y-1/2 after:-mt-1 after:-rotate-45"
+    "gap-x-1.5 p-2.5 pl-1.5 z-50 hidden peer-focus-within/target:inline-flex peer-hover/target:inline-flex absolute bottom-full mb-[calc(var(--tooltip-arrow-size)/1.5)] items-center min-w-max rounded-lg bg-slate-900 left-1/2 -translate-x-1/2 after:absolute after:content-[''] after:top-full after:left-1/2 after:-translate-x-1/2 after:bg-inherit after:rounded-sm after:h-[var(--tooltip-arrow-size)] after:w-[var(--tooltip-arrow-size)] after:-translate-y-1/2 after:-mt-1 after:-rotate-45"
   end
 
   defp direction_classes("bottom") do
-    "gap-x-1.5 p-2.5 pl-1.5 z-50 hidden items-center peer-focus-within/target:inline-flex peer-hover/target:inline-flex absolute top-full mt-[calc(var(--tooltip-arrow-size)/1.5)] min-w-max rounded-lg bg-slate-900 left-0 after:absolute after:content-[''] after:bottom-full after:left-1/2 after:-translate-x-1/2 after:bg-inherit after:rounded-sm after:h-[var(--tooltip-arrow-size)] after:w-[var(--tooltip-arrow-size)] after:translate-y-1/2 after:-mb-1 after:-rotate-45"
+    "gap-x-1.5 p-2.5 pl-1.5 z-50 hidden items-center peer-focus-within/target:inline-flex peer-hover/target:inline-flex absolute top-full mt-[calc(var(--tooltip-arrow-size)/1.5)] min-w-max rounded-lg bg-slate-900 left-1/2 -translate-x-1/2 after:absolute after:content-[''] after:bottom-full after:left-1/2 after:-translate-x-1/2 after:bg-inherit after:rounded-sm after:h-[var(--tooltip-arrow-size)] after:w-[var(--tooltip-arrow-size)] after:translate-y-1/2 after:-mb-1 after:-rotate-45"
   end
 end


### PR DESCRIPTION
## In this PR

- Fix the styling of the tooltips so that they are centered over the trigger element instead of aligning to the left side
- Add `class` attribute so custom classes can be added to the tooltip

### Before

![Screenshot 2025-01-10 at 2 39 41 PM](https://github.com/user-attachments/assets/e4db7790-702e-4500-b663-8edfccc965f9)

![Screenshot 2025-01-10 at 2 39 48 PM](https://github.com/user-attachments/assets/e52f3de2-a10e-4da5-ab7a-380673d59be6)

### After

![Screenshot 2025-01-10 at 2 39 59 PM](https://github.com/user-attachments/assets/110b5226-ab7a-4dbd-9ff7-06d230f9ed1d)

![Screenshot 2025-01-10 at 2 40 04 PM](https://github.com/user-attachments/assets/97406f3a-6284-4bf2-b834-be1fc6801a54)

![Screenshot 2025-01-10 at 2 46 12 PM](https://github.com/user-attachments/assets/d047015d-5fc6-44ef-b882-96411d5e95ef)

